### PR TITLE
created placeholder UCSBSubjects table (frontend)

### DIFF
--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,0 +1,6 @@
+GOOGLE_CLIENT_ID=see-instructions-in-readme
+GOOGLE_CLIENT_SECRET=see-instructions-in-readme
+ADMIN_EMAILS=phtcon@ucsb.edu
+MONGODB_URI=see-instructions-in-readme
+START_QTR=20221
+END_QTR=20222

--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,6 +1,0 @@
-GOOGLE_CLIENT_ID=see-instructions-in-readme
-GOOGLE_CLIENT_SECRET=see-instructions-in-readme
-ADMIN_EMAILS=phtcon@ucsb.edu
-MONGODB_URI=see-instructions-in-readme
-START_QTR=20221
-END_QTR=20222

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ build/
 
 ### Local Configuration ###
 .env
+
+.DS_Store

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,8 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import HomePage from "main/pages/HomePage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
+import LoadSubjectsPage from "main/pages/LoadSubjectsPage";
+
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -19,7 +21,12 @@ function App() {
         <Route exact path="/profile" element={<ProfilePage />} />
         {
           hasRole(currentUser, "ROLE_ADMIN") && <Route exact path="/admin/users" element={<AdminUsersPage />} />
+
         }
+        {
+        hasRole(currentUser, "ROLE_ADMIN") && <Route exact path="/admin/UCSBSubjects" element={<LoadSubjectsPage />} />
+        }
+
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/fixtures/loadsubjectsFixtures.js
+++ b/frontend/src/fixtures/loadsubjectsFixtures.js
@@ -1,0 +1,33 @@
+const loadsubjectsFixtures = {
+    threeSubjects: [
+        {
+            "id": 1,
+            "subjectCode": "PHIL",
+            "subjectTranslation": "Philosophy",
+            "deptCode": "PHIL",
+            "collegeCode": "L&S",
+            "relatedDeptCode": "null",
+            "inactive": true
+        },
+        {
+            "id": 2,
+            "subjectCode": "CMPSC",
+            "subjectTranslation": "Computer Science",
+            "deptCode": "CMPSC",
+            "collegeCode": "CoE",
+            "relatedDeptCode": "null",
+            "inactive": false
+        },
+        {
+            "id": 3,
+            "subjectCode": "ANTH",
+            "subjectTranslation": "Anthropology",
+            "deptCode": "ANTH",
+            "collegeCode": "L&S",
+            "relatedDeptCode": "null",
+            "inactive": false
+        }
+    ]
+}
+
+export default loadsubjectsFixtures;

--- a/frontend/src/main/components/LoadSubjects/LoadSubjectsTable.js
+++ b/frontend/src/main/components/LoadSubjects/LoadSubjectsTable.js
@@ -1,0 +1,41 @@
+import React from "react";
+import OurTable from "main/components/OurTable"
+
+const columns = [
+    {
+        Header: 'id',
+        accessor: 'id', // accessor is the "key" in the data
+    },
+    {
+        Header: 'SubjectCode',
+        accessor: 'subjectCode',
+      },
+      {
+        Header: 'SubjectTranslation',
+        accessor: 'subjectTranslation',
+      },
+      {
+        Header: 'DeptCode',
+        accessor: 'deptCode',
+      },
+      {
+        Header: 'CollegeCode',
+        accessor: 'collegeCode',
+      },
+      {
+        Header: 'RelatedDeptCode',
+        accessor: 'relatedDeptCode',
+      },
+      {
+        Header: 'Inactive',
+        accessor: (row) => String(row.inactive),
+        id: 'inactive',
+      },
+];
+
+export default function LoadSubjectsTable({ subjects }) {
+    return <OurTable
+        data={subjects}
+        columns={columns}
+        testid={"LoadSubjectsTable"} />;
+};

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -46,6 +46,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 hasRole(currentUser, "ROLE_ADMIN") && (
                   <NavDropdown title="Admin" id="appnavbar-admin-dropdown" data-testid="appnavbar-admin-dropdown" >
                     <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
+                    <NavDropdown.Item href="/admin/UCSBSubjects">Load Subjects</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/pages/LoadSubjectsPage.js
+++ b/frontend/src/main/pages/LoadSubjectsPage.js
@@ -1,0 +1,24 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import LoadSubjectsTable from "main/components/LoadSubjects/LoadSubjectsTable"
+
+import { useBackend } from "main/utils/useBackend";
+const LoadSubjectsPage = () => {
+
+    const { data: subjects, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            ["/api/admin/UCSBSubjects"],
+            { method: "GET", url: "/api/admin/UCSBSubjects/all" },
+            []
+        );
+
+    return (
+        <BasicLayout>
+            <h2>Load Subjects</h2>
+            <LoadSubjectsTable subjects={subjects} />
+        </BasicLayout>
+    );
+};
+
+export default LoadSubjectsPage;

--- a/frontend/src/stories/pages/HomePage/LoadSubjectsPage.stories.js
+++ b/frontend/src/stories/pages/HomePage/LoadSubjectsPage.stories.js
@@ -1,0 +1,14 @@
+
+import React from 'react';
+import loadsubjectsFixtures from 'fixtures/loadsubjectsFixtures';
+
+import LoadSubjectsTable from "main/components/LoadSubjects/LoadSubjectsTable";
+
+export default {
+    title: 'components/LoadSubjects/LoadSubjectsTable',
+    component: LoadSubjectsTable
+};
+
+const Template = () => <LoadSubjectsTable subjects={loadsubjectsFixtures.threeSubjects}/>;
+
+export const Default = Template.bind({});

--- a/frontend/src/tests/components/LoadSubjects/LoadSubjectsTable.test.js
+++ b/frontend/src/tests/components/LoadSubjects/LoadSubjectsTable.test.js
@@ -1,0 +1,48 @@
+import { render } from "@testing-library/react";
+import loadsubjectsFixtures from "fixtures/loadsubjectsFixtures";
+import LoadSubjectsTable from "main/components/LoadSubjects/LoadSubjectsTable"
+
+
+describe("LoadSubjectsTable tests", () => {
+
+    test("renders without crashing for empty table", () => {
+        render(
+            <LoadSubjectsTable subjects={[]} />
+        );
+    });
+
+    test("renders without crashing for three subjects", () => {
+        render(
+            <LoadSubjectsTable subjects={loadsubjectsFixtures.threeSubjects} />
+        );
+    });
+
+    test("Has the expected column headers and content", () => {
+        const { getByText, getByTestId } = render(
+          <LoadSubjectsTable subjects={loadsubjectsFixtures.threeSubjects}/>
+        );
+    
+        const expectedHeaders = ["id", "SubjectCode", "SubjectTranslation", "DeptCode", "CollegeCode", "RelatedDeptCode", "Inactive"];
+        const expectedFields = ["id", "subjectCode", "subjectTranslation", "deptCode", "collegeCode", "relatedDeptCode", "inactive"];
+        const testId = "LoadSubjectsTable";
+
+        expectedHeaders.forEach( (headerText)=> {
+            const header = getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expectedFields.forEach( (field)=> {
+          const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+          expect(header).toBeInTheDocument();
+        });
+
+        expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(getByTestId(`${testId}-cell-row-0-col-subjectCode`)).toHaveTextContent("PHIL");
+        expect(getByTestId(`${testId}-cell-row-0-col-inactive`)).toHaveTextContent("true");
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(getByTestId(`${testId}-cell-row-1-col-subjectCode`)).toHaveTextContent("CMPSC");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+        expect(getByTestId(`${testId}-cell-row-2-col-subjectCode`)).toHaveTextContent("ANTH");
+      });
+});
+

--- a/frontend/src/tests/pages/LoadSubjectsPage.test.js
+++ b/frontend/src/tests/pages/LoadSubjectsPage.test.js
@@ -1,0 +1,68 @@
+import { render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import LoadSubjectsPage from "main/pages/LoadSubjectsPage";
+import loadsubjectsFixtures from "fixtures/loadsubjectsFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import mockConsole from "jest-mock-console";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("LoadSubjectsPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "LoadSubjectsTable";
+
+    beforeEach( () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    test("renders without crashing on three subjects", async () => {
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/admin/UCSBSubjects").reply(200, loadsubjectsFixtures.threeSubjects);
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LoadSubjectsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByText("Load Subjects")).toBeInTheDocument());
+
+
+    });
+
+    test("renders empty table when backend unavailable", async () => {
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/admin/UCSBSubjects").timeout();
+
+        const restoreConsole = mockConsole();
+
+        const { queryByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LoadSubjectsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/admin/UCSBSubjects");
+        restoreConsole();
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+
+    });
+
+
+});

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsController.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 @Slf4j
 @Api(description = "API to handle CRUD operations for UCSB Subjects database")
-@RequestMapping("/api/UCSBSubjects")
+@RequestMapping("/api/admin/UCSBSubjects")
 @RestController
 public class UCSBSubjectsController extends ApiController {
     @Autowired

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsControllerTests.java
@@ -49,14 +49,14 @@ public class UCSBSubjectsControllerTests extends ControllerTestCase {
 
     @Test
     public void api_UCSBSubjects_all__logged_out__returns_403() throws Exception {
-        mockMvc.perform(get("/api/UCSBSubjects/all"))
+        mockMvc.perform(get("/api/admin/UCSBSubjects/all"))
                 .andExpect(status().is(403));
     }
 
     @WithMockUser(roles = { "USER" })
     @Test
     public void api_UCSBSubjects_all__user_logged_in__returns_200() throws Exception {
-        mockMvc.perform(get("/api/UCSBSubjects/all"))
+        mockMvc.perform(get("/api/admin/UCSBSubjects/all"))
                 .andExpect(status().isOk());
     }
 
@@ -82,7 +82,7 @@ public class UCSBSubjectsControllerTests extends ControllerTestCase {
         when(ucsbSubjectRepository.findById(eq("ANTH"))).thenReturn(Optional.of(us));
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects?subjectCode=ANTH"))
+        MvcResult response = mockMvc.perform(get("/api/admin/UCSBSubjects?subjectCode=ANTH"))
                 .andExpect(status().isOk()).andReturn();
 
         // assert
@@ -104,7 +104,7 @@ public class UCSBSubjectsControllerTests extends ControllerTestCase {
         when(ucsbSubjectRepository.findById(eq("ANTH"))).thenReturn(Optional.empty());
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects?subjectCode=ANTH"))
+        MvcResult response = mockMvc.perform(get("/api/admin/UCSBSubjects?subjectCode=ANTH"))
                 .andExpect(status().isNotFound()).andReturn();
 
         // assert
@@ -155,7 +155,7 @@ public class UCSBSubjectsControllerTests extends ControllerTestCase {
         when(ucsbSubjectRepository.findAll()).thenReturn(expectedUSs);
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/all"))
+        MvcResult response = mockMvc.perform(get("/api/admin/UCSBSubjects/all"))
                 .andExpect(status().isOk()).andReturn();
 
         // assert
@@ -184,7 +184,7 @@ public class UCSBSubjectsControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                delete("/api/UCSBSubjects?subjectCode=ANTH")
+                delete("/api/admin/UCSBSubjects?subjectCode=ANTH")
                         .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
@@ -204,7 +204,7 @@ public class UCSBSubjectsControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                delete("/api/UCSBSubjects?subjectCode=ANTH")
+                delete("/api/admin/UCSBSubjects?subjectCode=ANTH")
                         .with(csrf()))
                 .andExpect(status().isNotFound()).andReturn();
 
@@ -223,7 +223,7 @@ public class UCSBSubjectsControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                delete("/api/UCSBSubjects/all")
+                delete("/api/admin/UCSBSubjects/all")
                         .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
@@ -275,7 +275,7 @@ public class UCSBSubjectsControllerTests extends ControllerTestCase {
 
         when(ucsbSubjectsService.get()).thenReturn(expectedUSs);
 
-        MvcResult response = mockMvc.perform(post("/api/UCSBSubjects/load")
+        MvcResult response = mockMvc.perform(post("/api/admin/UCSBSubjects/load")
                 .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
@@ -337,7 +337,7 @@ public class UCSBSubjectsControllerTests extends ControllerTestCase {
 
         when(ucsbSubjectRepository.save(us1)).thenThrow(new org.springframework.dao.DuplicateKeyException("test"));
 
-        MvcResult response = mockMvc.perform(post("/api/UCSBSubjects/load")
+        MvcResult response = mockMvc.perform(post("/api/admin/UCSBSubjects/load")
                 .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 


### PR DESCRIPTION
# Overview

Implemented a UCSBSubjects Table placeholder for the frontend. Awaiting backend code to be able to implement different functionalities for the table.

# Issues Addressed
Closes #11 

# Details

- Added another DropDown Item in the Admin section of the Navbar called "Load Subjects"
- Created a page with a placeholder table within the Load Subjects tab that will populate all the subjects we currently have
- Created tests for crashing for empty table and 3 subjects parameters. In addition to seeing if the table have expected column headers and content
