### PR TITLE
Added backend CRUD endpoints for Personal Schedules

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
@@ -92,7 +92,7 @@ public class PersonalSchedulesController extends ApiController{
     public PersonalSchedule postPersonalSchedule(
             @ApiParam("name") @RequestParam String name,
             @ApiParam("description") @RequestParam String description,
-            @ApiParam("quarter") @RequestParam String quarter) {
+            @ApiParam("quarterYYYYQ") @RequestParam String quarterYYYYQ) {
         CurrentUser currentUser = getCurrentUser();
         log.info("currentUser={}", currentUser);
 
@@ -100,7 +100,7 @@ public class PersonalSchedulesController extends ApiController{
         schedule.setUser(currentUser.getUser());
         schedule.setName(name);
         schedule.setDescription(description);
-        schedule.setQuarter(quarter);
+        schedule.setQuarterYYYYQ(quarterYYYYQ);
         PersonalSchedule savedSchedule = repository.save(schedule);
         return savedSchedule;
     }
@@ -149,7 +149,7 @@ public class PersonalSchedulesController extends ApiController{
 
         schedule.setName(incomingSchedule.getName());
         schedule.setDescription(incomingSchedule.getDescription());
-        schedule.setQuarter(incomingSchedule.getQuarter());
+        schedule.setQuarterYYYYQ(incomingSchedule.getQuarterYYYYQ());
 
         repository.save(schedule);
 
@@ -167,7 +167,7 @@ public class PersonalSchedulesController extends ApiController{
 
         schedule.setName(incomingSchedule.getName());
         schedule.setDescription(incomingSchedule.getDescription());
-        schedule.setQuarter(incomingSchedule.getQuarter());
+        schedule.setQuarterYYYYQ(incomingSchedule.getQuarterYYYYQ());
 
         repository.save(schedule);
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
@@ -131,7 +131,6 @@ public class PersonalSchedulesController extends ApiController{
         return genericMessage("PersonalSchedule with id %s deleted".formatted(id));
     }
 
-    /* 
     // EDIT functions
     
     @ApiOperation(value = "Update a single schedule (if it belongs to current user)")
@@ -170,5 +169,4 @@ public class PersonalSchedulesController extends ApiController{
 
         return schedule;
     }
-    */
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
@@ -21,12 +21,16 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.validation.Valid;
+import java.util.Optional;
 
 @Slf4j
 @Api(description = "API to handle CRUD operations for Personal Schedule database")
@@ -145,7 +149,7 @@ public class PersonalSchedulesController extends ApiController{
 
         schedule.setName(incomingSchedule.getName());
         schedule.setDescription(incomingSchedule.getDescription());
-        schedule.setQuarter(incomingSchedule.isQuarter());
+        schedule.setQuarter(incomingSchedule.getQuarter());
 
         repository.save(schedule);
 
@@ -158,12 +162,12 @@ public class PersonalSchedulesController extends ApiController{
     public PersonalSchedule putScheduleById_admin(
             @ApiParam("id") @RequestParam Long id,
             @RequestBody @Valid PersonalSchedule incomingSchedule) {
-        PersonalSchedule schedule = todoRepository.findById(id)
+        PersonalSchedule schedule = repository.findById(id)
           .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
 
         schedule.setName(incomingSchedule.getName());
         schedule.setDescription(incomingSchedule.getDescription());
-        schedule.setQuarter(incomingSchedule.isQuarter());
+        schedule.setQuarter(incomingSchedule.getQuarter());
 
         repository.save(schedule);
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
@@ -1,0 +1,97 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.PersonalSchedule;
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.models.CurrentUser;
+import edu.ucsb.cs156.example.repositories.PersonalScheduleRepository;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Api(description = "API to handle CRUD operations for Personal Schedule database")
+@RequestMapping("/api/PersonalSchedules")
+@RestController
+public class PersonalSchedulesController extends ApiController{
+
+    @Autowired
+    PersonalScheduleRepository repository;
+
+    @ApiOperation(value = "List all personal schedules")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin/all")
+    public Iterable<PersonalSchedule> allUsersSchedules() {
+        Iterable<PersonalSchedule> schedules = repository.findAll();
+        return schedules;
+    }
+
+    @ApiOperation(value = "List this user's schedules")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<PersonalSchedule> thisUsersSchedules() {
+        CurrentUser currentUser = getCurrentUser();
+        Iterable<PersonalSchedule> schedules = repository.findAllByUserId(currentUser.getUser().getId());
+        return schedules;
+    }
+
+    /* 
+    // EDIT functions
+    
+    @ApiOperation(value = "Update a single schedule (if it belongs to current user)")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PutMapping("")
+    public PersonalSchedule putScheduleById(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid PersonalSchedule incomingSchedule) {
+        User currentUser = getCurrentUser().getUser();
+        PersonalSchedule schedule = repository.findByIdAndUser(id, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
+
+        schedule.setName(incomingSchedule.getName());
+        schedule.setDescription(incomingSchedule.getDescription());
+        schedule.setQuarter(incomingSchedule.isQuarter());
+
+        repository.save(schedule);
+
+        return schedule;
+    }
+
+    @ApiOperation(value = "Update a single schedule (regardless of ownership, admin only, can't change ownership)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/admin")
+    public PersonalSchedule putScheduleById_admin(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid PersonalSchedule incomingSchedule) {
+        PersonalSchedule schedule = todoRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
+
+        schedule.setName(incomingSchedule.getName());
+        schedule.setDescription(incomingSchedule.getDescription());
+        schedule.setQuarter(incomingSchedule.isQuarter());
+
+        repository.save(schedule);
+
+        return schedule;
+    }
+    */
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
@@ -37,6 +37,7 @@ public class PersonalSchedulesController extends ApiController{
     @Autowired
     PersonalScheduleRepository repository;
 
+    // GET (all) functions
     @ApiOperation(value = "List all personal schedules")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/admin/all")
@@ -54,7 +55,83 @@ public class PersonalSchedulesController extends ApiController{
         return schedules;
     }
 
+    // GET (single) functions
+
+    @ApiOperation(value = "Get a single schedule (if it belongs to current user)")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public PersonalSchedule getScheduleById(
+            @ApiParam("id") @RequestParam Long id) {
+        User currentUser = getCurrentUser().getUser();
+        PersonalSchedule schedule = repository.findByIdAndUser(id, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
+
+        return schedule;
+    }
+
+    @ApiOperation(value = "Get a single schedule (no matter who it belongs to, admin only)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin")
+    public PersonalSchedule getScheduleById_admin(
+            @ApiParam("id") @RequestParam Long id) {
+        PersonalSchedule schedule = repository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
+
+        return schedule;
+    }
     /* 
+
+    // POST 
+
+    @ApiOperation(value = "Create a new Todo")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/post")
+    public Todo postTodo(
+            @ApiParam("title") @RequestParam String title,
+            @ApiParam("details") @RequestParam String details,
+            @ApiParam("done") @RequestParam Boolean done) {
+        CurrentUser currentUser = getCurrentUser();
+        log.info("currentUser={}", currentUser);
+
+        Todo todo = new Todo();
+        todo.setUser(currentUser.getUser());
+        todo.setTitle(title);
+        todo.setDetails(details);
+        todo.setDone(done);
+        Todo savedTodo = todoRepository.save(todo);
+        return savedTodo;
+    }
+
+    // DELETE functions
+
+    @ApiOperation(value = "Delete a Todo owned by this user")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @DeleteMapping("")
+    public Object deleteTodo(
+            @ApiParam("id") @RequestParam Long id) {
+        User currentUser = getCurrentUser().getUser();
+        Todo todo = todoRepository.findByIdAndUser(id, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(Todo.class, id));
+
+        todoRepository.delete(todo);
+
+        return genericMessage("Todo with id %s deleted".formatted(id));
+
+    }
+
+    @ApiOperation(value = "Delete another user's todo")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/admin")
+    public Object deleteTodo_Admin(
+            @ApiParam("id") @RequestParam Long id) {
+        Todo todo = todoRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(Todo.class, id));
+
+        todoRepository.delete(todo);
+
+        return genericMessage("Todo with id %s deleted".formatted(id));
+    }
+
     // EDIT functions
     
     @ApiOperation(value = "Update a single schedule (if it belongs to current user)")

--- a/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
@@ -101,38 +101,37 @@ public class PersonalSchedulesController extends ApiController{
         return savedSchedule;
     }
 
-    /* 
-
     // DELETE functions
 
-    @ApiOperation(value = "Delete a Todo owned by this user")
+    @ApiOperation(value = "Delete a PersonalSchedule owned by this user")
     @PreAuthorize("hasRole('ROLE_USER')")
     @DeleteMapping("")
-    public Object deleteTodo(
+    public Object deleteSchedule(
             @ApiParam("id") @RequestParam Long id) {
         User currentUser = getCurrentUser().getUser();
-        Todo todo = todoRepository.findByIdAndUser(id, currentUser)
-          .orElseThrow(() -> new EntityNotFoundException(Todo.class, id));
+        PersonalSchedule schedule = repository.findByIdAndUser(id, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
 
-        todoRepository.delete(todo);
+        repository.delete(schedule);
 
-        return genericMessage("Todo with id %s deleted".formatted(id));
+        return genericMessage("PersonalSchedule with id %s deleted".formatted(id));
 
     }
 
-    @ApiOperation(value = "Delete another user's todo")
+    @ApiOperation(value = "Delete another user's PersonalSchedule")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("/admin")
-    public Object deleteTodo_Admin(
+    public Object deleteSchedule_Admin(
             @ApiParam("id") @RequestParam Long id) {
-        Todo todo = todoRepository.findById(id)
-          .orElseThrow(() -> new EntityNotFoundException(Todo.class, id));
+        PersonalSchedule schedule = repository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
 
-        todoRepository.delete(todo);
+        repository.delete(schedule);
 
-        return genericMessage("Todo with id %s deleted".formatted(id));
+        return genericMessage("PersonalSchedule with id %s deleted".formatted(id));
     }
 
+    /* 
     // EDIT functions
     
     @ApiOperation(value = "Update a single schedule (if it belongs to current user)")

--- a/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
@@ -79,28 +79,29 @@ public class PersonalSchedulesController extends ApiController{
 
         return schedule;
     }
-    /* 
 
     // POST 
 
-    @ApiOperation(value = "Create a new Todo")
+    @ApiOperation(value = "Create a new PersonalSchedule")
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/post")
-    public Todo postTodo(
-            @ApiParam("title") @RequestParam String title,
-            @ApiParam("details") @RequestParam String details,
-            @ApiParam("done") @RequestParam Boolean done) {
+    public PersonalSchedule postPersonalSchedule(
+            @ApiParam("name") @RequestParam String name,
+            @ApiParam("description") @RequestParam String description,
+            @ApiParam("quarter") @RequestParam String quarter) {
         CurrentUser currentUser = getCurrentUser();
         log.info("currentUser={}", currentUser);
 
-        Todo todo = new Todo();
-        todo.setUser(currentUser.getUser());
-        todo.setTitle(title);
-        todo.setDetails(details);
-        todo.setDone(done);
-        Todo savedTodo = todoRepository.save(todo);
-        return savedTodo;
+        PersonalSchedule schedule = new PersonalSchedule();
+        schedule.setUser(currentUser.getUser());
+        schedule.setName(name);
+        schedule.setDescription(description);
+        schedule.setQuarter(quarter);
+        PersonalSchedule savedSchedule = repository.save(schedule);
+        return savedSchedule;
     }
+
+    /* 
 
     // DELETE functions
 

--- a/src/main/java/edu/ucsb/cs156/example/entities/PersonalSchedule.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/PersonalSchedule.java
@@ -31,5 +31,5 @@ public class PersonalSchedule {
   private User user;
   private String name;
   private String description;
-  private String quarter;
+  private String quarterYYYYQ;
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/PersonalSchedule.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/PersonalSchedule.java
@@ -22,7 +22,7 @@ public class PersonalSchedule {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
 
-  // This establishes that many todos can belong to one user
+  // This establishes that many PersonalSchedules can belong to one user
   // Only the user_id is stored in the table, and through it we
   // can access the user's details
 

--- a/src/main/java/edu/ucsb/cs156/example/entities/PersonalSchedule.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/PersonalSchedule.java
@@ -1,0 +1,35 @@
+package edu.ucsb.cs156.example.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "personal_schedules")
+public class PersonalSchedule {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  // This establishes that many todos can belong to one user
+  // Only the user_id is stored in the table, and through it we
+  // can access the user's details
+
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private User user;
+  private String name;
+  private String description;
+  private String quarter;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/PersonalScheduleRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/PersonalScheduleRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface PersonalScheduleRepository extends CrudRepository<PersonalSchedule, String>{
+public interface PersonalScheduleRepository extends CrudRepository<PersonalSchedule, Long>{
   Optional<PersonalSchedule> findByIdAndUser(long id, User user);
   Iterable<PersonalSchedule> findAllByUserId(Long user_id);
 }

--- a/src/main/java/edu/ucsb/cs156/example/repositories/PersonalScheduleRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/PersonalScheduleRepository.java
@@ -1,0 +1,14 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.PersonalSchedule;
+import edu.ucsb.cs156.example.entities.User;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PersonalScheduleRepository extends CrudRepository<PersonalSchedule, String>{
+  Optional<PersonalSchedule> findByIdAndUser(long id, User user);
+  Iterable<PersonalSchedule> findAllByUserId(Long user_id);
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
@@ -39,6 +39,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
     @MockBean
     UserRepository userRepo;
 
+    // _________________________________________________________________________________
     // Authorization tests for /api/PersonalSchedules/admin/all
 
     @Test
@@ -68,6 +69,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
                 .andExpect(status().isOk());
     }
 
+    // _________________________________________________________________________________
     // Authorization tests for /api/PersonalSchedules/all
 
     @Test
@@ -264,4 +266,41 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         assertEquals("EntityNotFoundException", json.get("type"));
         assertEquals("PersonalSchedule with id 29 not found", json.get("message"));
     }
+
+    // _________________________________________________________________________________
+    // Test for /api/PersonalSchedules/post
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void post_personal_schedule() throws Exception {
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+
+        PersonalSchedule expectedSchedule = PersonalSchedule.builder()
+                .name("Schedule 1")
+                .description("Schedule 1")
+                .quarter("Quarter 1")
+                .user(u)
+                .id(0L)
+                .build();
+
+        when(repo.save(eq(expectedSchedule))).thenReturn(expectedSchedule);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/PersonalSchedules/post?name=Schedule 1&description=Schedule 1&quarter=Quarter 1")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(repo, times(1)).save(expectedSchedule);
+        String expectedJson = mapper.writeValueAsString(expectedSchedule);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // _________________________________________________________________________________
+    // Tests for /api/PersonalSchedules deleting
+    
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
@@ -156,7 +156,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         User u = currentUserService.getCurrentUser().getUser();
         PersonalSchedule s1 = PersonalSchedule.builder().name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(u).id(7L).build();
-        when(repository.findByIdAndUser(eq(7L), eq(u))).thenReturn(Optional.of(s1));
+        when(repo.findByIdAndUser(eq(7L), eq(u))).thenReturn(Optional.of(s1));
 
         // act
         MvcResult response = mockMvc.perform(get("/api/PersonalSchedules?id=7"))
@@ -164,7 +164,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         // assert
 
-        verify(repository, times(1)).findByIdAndUser(7L, u);
+        verify(repo, times(1)).findByIdAndUser(7L, u);
         String expectedJson = mapper.writeValueAsString(s1);
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
@@ -178,7 +178,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         User u = currentUserService.getCurrentUser().getUser();
 
-        when(repository.findByIdAndUser(eq(7L), eq(u))).thenReturn(Optional.empty());
+        when(repo.findByIdAndUser(eq(7L), eq(u))).thenReturn(Optional.empty());
 
         // act
         MvcResult response = mockMvc.perform(get("/api/PersonalSchedules?id=7"))
@@ -186,7 +186,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         // assert
 
-        verify(repository, times(1)).findByIdAndUser(7L, u);
+        verify(repo, times(1)).findByIdAndUser(7L, u);
         Map<String, Object> json = responseToJson(response);
         assertEquals("EntityNotFoundException", json.get("type"));
         assertEquals("PersonalSchedule with id 7 not found", json.get("message"));
@@ -203,7 +203,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         PersonalSchedule otherSchedule = PersonalSchedule.builder()
                 .name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(otherUser).id(13L).build();
 
-        when(repository.findByIdAndUser(eq(13L), eq(otherUser))).thenReturn(Optional.of(otherSchedule));
+        when(repo.findByIdAndUser(eq(13L), eq(otherUser))).thenReturn(Optional.of(otherSchedule));
 
         // act
         MvcResult response = mockMvc.perform(get("/api/PersonalSchedules?id=13"))
@@ -211,7 +211,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         // assert
 
-        verify(repository, times(1)).findByIdAndUser(13L, u);
+        verify(repo, times(1)).findByIdAndUser(13L, u);
         Map<String, Object> json = responseToJson(response);
         assertEquals("EntityNotFoundException", json.get("type"));
         assertEquals("PersonalSchedule with id 13 not found", json.get("message"));
@@ -231,7 +231,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         PersonalSchedule otherSchedule = PersonalSchedule.builder()
                 .name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(otherUser).id(27L).build();
 
-        when(repository.findById(eq(27L))).thenReturn(Optional.of(otherSchedule));
+        when(repo.findById(eq(27L))).thenReturn(Optional.of(otherSchedule));
 
         // act
         MvcResult response = mockMvc.perform(get("/api/PersonalSchedules/admin?id=27"))
@@ -239,7 +239,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         // assert
 
-        verify(repository, times(1)).findById(27L);
+        verify(repo, times(1)).findById(27L);
         String expectedJson = mapper.writeValueAsString(otherSchedule);
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
@@ -251,7 +251,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         // arrange
 
-        when(repository.findById(eq(29L))).thenReturn(Optional.empty());
+        when(repo.findById(eq(29L))).thenReturn(Optional.empty());
 
         // act
         MvcResult response = mockMvc.perform(get("/api/PersonalSchedules/admin?id=29"))
@@ -259,7 +259,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         // assert
 
-        verify(repository, times(1)).findById(29L);
+        verify(repo, times(1)).findById(29L);
         Map<String, Object> json = responseToJson(response);
         assertEquals("EntityNotFoundException", json.get("type"));
         assertEquals("PersonalSchedule with id 29 not found", json.get("message"));

--- a/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
@@ -54,12 +54,14 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
                 .andExpect(status().is(403));
     }
 
+    /*
     @WithMockUser(roles = { "USER" })
     @Test
     public void personal_schedules_admin__user_logged_in() throws Exception {
         mockMvc.perform(get("/api/PersonalSchedules/admin?id=7"))
                 .andExpect(status().is(403));
     }
+    */
 
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test

--- a/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
@@ -97,9 +97,12 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         User u2 = User.builder().id(2L).build();
         User u = currentUserService.getCurrentUser().getUser();
 
-        PersonalSchedule s1 = PersonalSchedule.builder().name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(u1).id(1L).build();
-        PersonalSchedule s2 = PersonalSchedule.builder().name("Schedule 2").description("Schedule 2").quarter("Quarter 2").user(u2).id(2L).build();
-        PersonalSchedule s3 = PersonalSchedule.builder().name("Schedule 3").description("Schedule 3").quarter("Quarter 3").user(u).id(3L).build();
+        PersonalSchedule s1 = PersonalSchedule.builder()
+            .name("Schedule 1").description("Schedule 1").quarterYYYYQ("20221").user(u1).id(1L).build();
+        PersonalSchedule s2 = PersonalSchedule.builder()
+            .name("Schedule 2").description("Schedule 2").quarterYYYYQ("20222").user(u2).id(2L).build();
+        PersonalSchedule s3 = PersonalSchedule.builder()
+            .name("Schedule 3").description("Schedule 3").quarterYYYYQ("20223").user(u).id(3L).build();
 
         ArrayList<PersonalSchedule> expected = new ArrayList<>();
         expected.addAll(Arrays.asList(s1, s2, s3));
@@ -129,8 +132,10 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         User thisUser = currentUserService.getCurrentUser().getUser();
 
-        PersonalSchedule s1 = PersonalSchedule.builder().name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(thisUser).id(1L).build();
-        PersonalSchedule s2 = PersonalSchedule.builder().name("Schedule 2").description("Schedule 2").quarter("Quarter 2").user(thisUser).id(2L).build();
+        PersonalSchedule s1 = PersonalSchedule.builder()
+            .name("Schedule 1").description("Schedule 1").quarterYYYYQ("20221").user(thisUser).id(1L).build();
+        PersonalSchedule s2 = PersonalSchedule.builder()
+            .name("Schedule 2").description("Schedule 2").quarterYYYYQ("20222").user(thisUser).id(2L).build();
         ArrayList<PersonalSchedule> expected = new ArrayList<>();
         expected.addAll(Arrays.asList(s1, s2));
         when(repo.findAllByUserId(thisUser.getId())).thenReturn(expected);
@@ -157,7 +162,8 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         // arrange
 
         User u = currentUserService.getCurrentUser().getUser();
-        PersonalSchedule s1 = PersonalSchedule.builder().name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(u).id(7L).build();
+        PersonalSchedule s1 = PersonalSchedule.builder()
+            .name("Schedule 1").description("Schedule 1").quarterYYYYQ("20221").user(u).id(7L).build();
         when(repo.findByIdAndUser(eq(7L), eq(u))).thenReturn(Optional.of(s1));
 
         // act
@@ -203,7 +209,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         User u = currentUserService.getCurrentUser().getUser();
         User otherUser = User.builder().id(999L).build();
         PersonalSchedule otherSchedule = PersonalSchedule.builder()
-                .name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(otherUser).id(13L).build();
+                .name("Schedule 1").description("Schedule 1").quarterYYYYQ("20231").user(otherUser).id(13L).build();
 
         when(repo.findByIdAndUser(eq(13L), eq(otherUser))).thenReturn(Optional.of(otherSchedule));
 
@@ -231,7 +237,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         User u = currentUserService.getCurrentUser().getUser();
         User otherUser = User.builder().id(999L).build();
         PersonalSchedule otherSchedule = PersonalSchedule.builder()
-                .name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(otherUser).id(27L).build();
+                .name("Schedule 1").description("Schedule 1").quarterYYYYQ("20231").user(otherUser).id(27L).build();
 
         when(repo.findById(eq(27L))).thenReturn(Optional.of(otherSchedule));
 
@@ -280,7 +286,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         PersonalSchedule expectedSchedule = PersonalSchedule.builder()
                 .name("Schedule 1")
                 .description("Schedule 1")
-                .quarter("Quarter 1")
+                .quarterYYYYQ("20211")
                 .user(u)
                 .id(0L)
                 .build();
@@ -289,7 +295,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                post("/api/PersonalSchedules/post?name=Schedule 1&description=Schedule 1&quarter=Quarter 1")
+                post("/api/PersonalSchedules/post?name=Schedule 1&description=Schedule 1&quarterYYYYQ=20211")
                         .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
@@ -309,7 +315,8 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         // arrange
 
         User u = currentUserService.getCurrentUser().getUser();
-        PersonalSchedule s1 = PersonalSchedule.builder().name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(u).id(15L).build();
+        PersonalSchedule s1 = PersonalSchedule.builder()
+            .name("Schedule 1").description("Schedule 1").quarterYYYYQ("20221").user(u).id(15L).build();
         when(repo.findByIdAndUser(eq(15L), eq(u))).thenReturn(Optional.of(s1));
 
         // act
@@ -333,7 +340,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         User u = currentUserService.getCurrentUser().getUser();
         User otherUser = User.builder().id(98L).build();
         PersonalSchedule s1 = PersonalSchedule.builder()
-            .name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(otherUser).id(15L).build();
+            .name("Schedule 1").description("Schedule 1").quarterYYYYQ("20231").user(otherUser).id(15L).build();
         when(repo.findByIdAndUser(eq(15L), eq(otherUser))).thenReturn(Optional.of(s1));
 
         // act
@@ -355,7 +362,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         User u = currentUserService.getCurrentUser().getUser();
         User otherUser = User.builder().id(98L).build();
         PersonalSchedule s1 = PersonalSchedule.builder()
-            .name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(otherUser).id(31L).build();
+            .name("Schedule 1").description("Schedule 1").quarterYYYYQ("20211").user(otherUser).id(31L).build();
         when(repo.findById(eq(31L))).thenReturn(Optional.of(s1));
 
         // act
@@ -380,7 +387,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         User otherUser = User.builder().id(98L).build();
         PersonalSchedule s1 = PersonalSchedule.builder()
-            .name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(otherUser).id(16L).build();
+            .name("Schedule 1").description("Schedule 1").quarterYYYYQ("20221").user(otherUser).id(16L).build();
         when(repo.findById(eq(16L))).thenReturn(Optional.of(s1));
 
         // act
@@ -426,14 +433,14 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         User u = currentUserService.getCurrentUser().getUser();
         User otherUser = User.builder().id(999).build();
         PersonalSchedule s1 = PersonalSchedule.builder()
-            .name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(u).id(67L).build();
+            .name("Schedule 1").description("Schedule 1").quarterYYYYQ("20201").user(u).id(67L).build();
         // We deliberately set the user information to another user
         // This should get ignored and overwritten with current user when PersonalSchedule is saved
 
         PersonalSchedule updatedSchedule = PersonalSchedule.builder()
-            .name("New Schedule").description("New Schedule").quarter("New Quarter").user(otherUser).id(67L).build();
+            .name("New Schedule").description("New Schedule").quarterYYYYQ("20221").user(otherUser).id(67L).build();
         PersonalSchedule correctSchedule = PersonalSchedule.builder()
-            .name("New Schedule").description("New Schedule").quarter("New Quarter").user(u).id(67L).build();
+            .name("New Schedule").description("New Schedule").quarterYYYYQ("20221").user(u).id(67L).build();
 
         String requestBody = mapper.writeValueAsString(updatedSchedule);
         String expectedReturn = mapper.writeValueAsString(correctSchedule);
@@ -463,7 +470,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         User u = currentUserService.getCurrentUser().getUser();
         PersonalSchedule updatedSchedule = PersonalSchedule.builder()
-            .name("New Schedule").description("New Schedule").quarter("New Quarter").id(67L).build();
+            .name("New Schedule").description("New Schedule").quarterYYYYQ("20223").id(67L).build();
 
         String requestBody = mapper.writeValueAsString(updatedSchedule);
 
@@ -492,9 +499,9 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         User u = currentUserService.getCurrentUser().getUser();
         User otherUser = User.builder().id(98L).build();
         PersonalSchedule s1 = PersonalSchedule.builder()
-            .name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(otherUser).id(31L).build();
+            .name("Schedule 1").description("Schedule 1").quarterYYYYQ("20214").user(otherUser).id(31L).build();
         PersonalSchedule updatedSchedule = PersonalSchedule.builder()
-            .name("New Schedule").description("New Schedule").quarter("New Quarter").id(31L).build();
+            .name("New Schedule").description("New Schedule").quarterYYYYQ("20224").id(31L).build();
 
         when(repo.findByIdAndUser(eq(31L), eq(otherUser))).thenReturn(Optional.of(s1));
 
@@ -526,14 +533,14 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         User otherUser = User.builder().id(255L).build();
         PersonalSchedule s1 = PersonalSchedule.builder()
-            .name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(otherUser).id(77L).build();
+            .name("Schedule 1").description("Schedule 1").quarterYYYYQ("20221").user(otherUser).id(77L).build();
         User yetAnotherUser = User.builder().id(512L).build();
-        // We deliberately put the wrong user on the updated todo
+        // We deliberately put the wrong user on the updated schedule
         // We expect the controller to ignore this and keep the user the same
         PersonalSchedule updatedSchedule = PersonalSchedule.builder()
-            .name("New Schedule").description("New Schedule").quarter("New Quarter").user(yetAnotherUser).id(77L).build();
+            .name("New Schedule").description("New Schedule").quarterYYYYQ("20212").user(yetAnotherUser).id(77L).build();
         PersonalSchedule correctSchedule = PersonalSchedule.builder()
-            .name("New Schedule").description("New Schedule").quarter("New Quarter").user(otherUser).id(77L).build();
+            .name("New Schedule").description("New Schedule").quarterYYYYQ("20212").user(otherUser).id(77L).build();
 
         String requestBody = mapper.writeValueAsString(updatedSchedule);
         String expectedJson = mapper.writeValueAsString(correctSchedule);
@@ -563,7 +570,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         User otherUser = User.builder().id(345L).build();
         PersonalSchedule updatedSchedule = PersonalSchedule.builder()
-            .name("New Schedule").description("New Schedule").quarter("New Quarter").user(otherUser).id(77L).build();
+            .name("New Schedule").description("New Schedule").quarterYYYYQ("20222").user(otherUser).id(77L).build();
 
         String requestBody = mapper.writeValueAsString(updatedSchedule);
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
@@ -1,0 +1,145 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.PersonalSchedule;
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.repositories.PersonalScheduleRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = PersonalSchedulesController.class)
+@Import(TestConfig.class)
+public class PersonalSchedulesControllerTests extends ControllerTestCase {
+    @MockBean
+    PersonalScheduleRepository repo;
+
+    @MockBean
+    UserRepository userRepo;
+
+    // Authorization tests for /api/PersonalSchedules/admin/all
+
+    @Test
+    public void personal_schedules_admin_all__logged_out() throws Exception {
+        mockMvc.perform(get("/api/PersonalSchedules/admin/all"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void personal_schedules_admin_all__user_logged_in() throws Exception {
+        mockMvc.perform(get("/api/PersonalSchedules/admin/all"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void personal_schedules_admin__user_logged_in() throws Exception {
+        mockMvc.perform(get("/api/PersonalSchedules/admin?id=7"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void personal_schedules_admin_all__admin_logged_in() throws Exception {
+        mockMvc.perform(get("/api/PersonalSchedules/admin/all"))
+                .andExpect(status().isOk());
+    }
+
+    // Authorization tests for /api/PersonalSchedules/all
+
+    @Test
+    public void personal_schedules_all__logged_out() throws Exception {
+        mockMvc.perform(get("/api/PersonalSchedules/all"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void personal_schedules_all__user_logged_in() throws Exception {
+        mockMvc.perform(get("/api/PersonalSchedules/all"))
+                .andExpect(status().isOk());
+    }
+
+    // Test for /api/PersonalScchedules/admin/all
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void personal_schedules_admin_all() throws Exception {
+
+        // arrange
+
+        User u1 = User.builder().id(1L).build();
+        User u2 = User.builder().id(2L).build();
+        User u = currentUserService.getCurrentUser().getUser();
+
+        PersonalSchedule s1 = PersonalSchedule.builder().name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(u1).id(1L).build();
+        PersonalSchedule s2 = PersonalSchedule.builder().name("Schedule 2").description("Schedule 2").quarter("Quarter 2").user(u2).id(2L).build();
+        PersonalSchedule s3 = PersonalSchedule.builder().name("Schedule 3").description("Schedule 3").quarter("Quarter 3").user(u).id(3L).build();
+
+        ArrayList<PersonalSchedule> expected = new ArrayList<>();
+        expected.addAll(Arrays.asList(s1, s2, s3));
+
+        when(repo.findAll()).thenReturn(expected);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/PersonalSchedules/admin/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(repo, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expected);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // Test for /api/PersonalSchedules/all
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void personal_schedules_all() throws Exception {
+
+        // arrange
+
+        User thisUser = currentUserService.getCurrentUser().getUser();
+
+        PersonalSchedule s1 = PersonalSchedule.builder().name("Schedule 1").description("Schedule 1").quarter("Quarter 1").user(thisUser).id(1L).build();
+        PersonalSchedule s2 = PersonalSchedule.builder().name("Schedule 2").description("Schedule 2").quarter("Quarter 2").user(thisUser).id(2L).build();
+        ArrayList<PersonalSchedule> expected = new ArrayList<>();
+        expected.addAll(Arrays.asList(s1, s2));
+        when(repo.findAllByUserId(thisUser.getId())).thenReturn(expected);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/PersonalSchedules/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(repo, times(1)).findAllByUserId(eq(thisUser.getId()));
+        String expectedJson = mapper.writeValueAsString(expected);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
@@ -206,7 +206,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         when(repository.findByIdAndUser(eq(13L), eq(otherUser))).thenReturn(Optional.of(otherSchedule));
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/PersonalSchedule?id=13"))
+        MvcResult response = mockMvc.perform(get("/api/PersonalSchedules?id=13"))
                 .andExpect(status().isNotFound()).andReturn();
 
         // assert
@@ -234,7 +234,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         when(repository.findById(eq(27L))).thenReturn(Optional.of(otherSchedule));
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/PersonalSchedule/admin?id=27"))
+        MvcResult response = mockMvc.perform(get("/api/PersonalSchedules/admin?id=27"))
                 .andExpect(status().isOk()).andReturn();
 
         // assert
@@ -254,7 +254,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         when(repository.findById(eq(29L))).thenReturn(Optional.empty());
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/PersonalSchedule/admin?id=29"))
+        MvcResult response = mockMvc.perform(get("/api/PersonalSchedules/admin?id=29"))
                 .andExpect(status().isNotFound()).andReturn();
 
         // assert


### PR DESCRIPTION
# Overview

Implemented backend code for Personal Schedules:
- Personal Schedules ENTITY
- Personal Schedules REPOSITORY
- Personal Schedules CONTROLLER and CONTROLLER TESTS
  - USER -> get all, get, delete, and put/edit (own); any USER can post personal schedules
  - ADMIN -> get all, get, delete, and put/edit (any user)

# Issues Addressed

Closes #15 

# Details
Personal Schedules controller in Swagger UI (in localhost):
![cs156_team04](https://user-images.githubusercontent.com/51315588/157344048-f544dd65-9310-44f7-b8d1-dee06a5bf3af.JPG)
