### PR TITLE
BUGFIX: Load Subjects (from PR #29)

### DIFF
--- a/frontend/src/fixtures/loadsubjectsFixtures.js
+++ b/frontend/src/fixtures/loadsubjectsFixtures.js
@@ -1,33 +1,129 @@
 const loadsubjectsFixtures = {
-    threeSubjects: [
-        {
-            "id": 1,
-            "subjectCode": "PHIL",
-            "subjectTranslation": "Philosophy",
-            "deptCode": "PHIL",
-            "collegeCode": "L&S",
-            "relatedDeptCode": "null",
-            "inactive": true
-        },
-        {
-            "id": 2,
-            "subjectCode": "CMPSC",
-            "subjectTranslation": "Computer Science",
-            "deptCode": "CMPSC",
-            "collegeCode": "CoE",
-            "relatedDeptCode": "null",
-            "inactive": false
-        },
-        {
-            "id": 3,
-            "subjectCode": "ANTH",
-            "subjectTranslation": "Anthropology",
-            "deptCode": "ANTH",
-            "collegeCode": "L&S",
-            "relatedDeptCode": "null",
-            "inactive": false
-        }
-    ]
-}
+  oneSubject: [
+    {
+      id: 1,
+      subjectCode: 'PHIL',
+      subjectTranslation: 'Philosophy',
+      deptCode: 'PHIL',
+      collegeCode: 'L&S',
+      relatedDeptCode: 'null',
+      inactive: true,
+    },
+  ],
+  threeSubjects: [
+    {
+      id: 1,
+      subjectCode: 'PHIL',
+      subjectTranslation: 'Philosophy',
+      deptCode: 'PHIL',
+      collegeCode: 'L&S',
+      relatedDeptCode: 'null',
+      inactive: true,
+    },
+    {
+      id: 2,
+      subjectCode: 'CMPSC',
+      subjectTranslation: 'Computer Science',
+      deptCode: 'CMPSC',
+      collegeCode: 'CoE',
+      relatedDeptCode: 'null',
+      inactive: false,
+    },
+    {
+      id: 3,
+      subjectCode: 'ANTH',
+      subjectTranslation: 'Anthropology',
+      deptCode: 'ANTH',
+      collegeCode: 'L&S',
+      relatedDeptCode: 'null',
+      inactive: false,
+    },
+  ],
+  fourSubjects: [
+    {
+      id: 1,
+      subjectCode: 'PHIL',
+      subjectTranslation: 'Philosophy',
+      deptCode: 'PHIL',
+      collegeCode: 'L&S',
+      relatedDeptCode: 'null',
+      inactive: true,
+    },
+    {
+      id: 2,
+      subjectCode: 'CMPSC',
+      subjectTranslation: 'Computer Science',
+      deptCode: 'CMPSC',
+      collegeCode: 'CoE',
+      relatedDeptCode: 'null',
+      inactive: false,
+    },
+    {
+      id: 3,
+      subjectCode: 'ANTH',
+      subjectTranslation: 'Anthropology',
+      deptCode: 'ANTH',
+      collegeCode: 'L&S',
+      relatedDeptCode: 'null',
+      inactive: false,
+    },
+    {
+      id: 4,
+      subjectCode: 'ANTH',
+      subjectTranslation: 'Anthropology',
+      deptCode: 'ANTH',
+      collegeCode: 'L&S',
+      relatedDeptCode: 'null',
+      inactive: false,
+    },
+  ],
+  fiveSubjects: [
+    {
+      id: 1,
+      subjectCode: 'PHIL',
+      subjectTranslation: 'Philosophy',
+      deptCode: 'PHIL',
+      collegeCode: 'L&S',
+      relatedDeptCode: 'null',
+      inactive: true,
+    },
+    {
+      id: 2,
+      subjectCode: 'CMPSC',
+      subjectTranslation: 'Computer Science',
+      deptCode: 'CMPSC',
+      collegeCode: 'CoE',
+      relatedDeptCode: 'null',
+      inactive: false,
+    },
+    {
+      id: 3,
+      subjectCode: 'ANTH',
+      subjectTranslation: 'Anthropology',
+      deptCode: 'ANTH',
+      collegeCode: 'L&S',
+      relatedDeptCode: 'null',
+      inactive: false,
+    },
+    {
+      id: 4,
+      subjectCode: 'ANTH',
+      subjectTranslation: 'Anthropology',
+      deptCode: 'ANTH',
+      collegeCode: 'L&S',
+      relatedDeptCode: 'null',
+      inactive: false,
+    },
+    {
+      id: 5,
+      subjectCode: 'ANTH',
+      subjectTranslation: 'Anthropology',
+      deptCode: 'ANTH',
+      collegeCode: 'L&S',
+      relatedDeptCode: 'null',
+      inactive: false,
+    },
+  ],
+};
 
 export default loadsubjectsFixtures;

--- a/frontend/src/main/pages/LoadSubjectsPage.js
+++ b/frontend/src/main/pages/LoadSubjectsPage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import BasicLayout from 'main/layouts/BasicLayout/BasicLayout';
-import LoadSubjectsTable from 'main/components/LoadSubjects/LoadSubjectsTable';
+import UCSBSubjectsTable from 'main/components/UCSBSubjects/UCSBSubjectsTable';
 import { Button } from 'react-bootstrap';
 import { toast } from 'react-toastify';
 import { useBackendMutation } from 'main/utils/useBackend';
@@ -50,7 +50,7 @@ const LoadSubjectsPage = () => {
   return (
     <BasicLayout>
       <h2>Subjects</h2>
-      <LoadSubjectsTable subjects={subjects} />
+      <UCSBSubjectsTable subjects={subjects} />
       <Button
         variant="primary"
         data-testid="subjectsLoad"

--- a/frontend/src/main/pages/LoadSubjectsPage.js
+++ b/frontend/src/main/pages/LoadSubjectsPage.js
@@ -26,14 +26,21 @@ const LoadSubjectsPage = () => {
     method: 'POST',
   });
 
+  subjectsCount = subjects.length;
+
   const onSuccess = (subjects) => {
-    if (subjectsCount === subjects.length) {
+    if (subjects.length - subjectsCount === 0) {
       toast('No new subjects were loaded');
     } else {
-      toast(`${subjects.length} subjects loaded`);
-      subjectsCount = subjects.length;
+      if (subjects.length - subjectsCount === 1) {
+        toast(`1 new subject was loaded`);
+      } else {
+        toast(`${subjects.length - subjectsCount} new subjects were loaded`);
+      }
     }
+    subjectsCount = subjects.length;
   };
+
   const postMutation = useBackendMutation(
     objectToAxiosParams,
     {

--- a/frontend/src/tests/pages/LoadSubjectsPage.test.js
+++ b/frontend/src/tests/pages/LoadSubjectsPage.test.js
@@ -36,7 +36,7 @@ jest.mock('react-router-dom', () => {
 describe('LoadSubjectsPage tests', () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const testId = 'LoadSubjectsTable';
+  const testId = 'UCSBSubjectsTable';
 
   beforeEach(() => {
     axiosMock.reset();
@@ -132,7 +132,7 @@ describe('LoadSubjectsPage tests', () => {
     expect(queryByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent('1');
 
     await waitFor(() => {
-      expect(mockToast).toBeCalledWith('3 subjects loaded');
+      expect(mockToast).toBeCalledWith('3 new subjects were loaded');
     });
   });
 
@@ -168,6 +168,196 @@ describe('LoadSubjectsPage tests', () => {
 
     await waitFor(() => {
       expect(mockToast).toBeCalledWith('No new subjects were loaded');
+    });
+    await waitFor(() => {
+      expect(mockToast).not.toBeCalledWith('3 new subjects were loaded');
+    });
+  });
+
+  test('test that toastify retains loaded subjects on a reload', async () => {
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet('api/admin/UCSBSubjects/all')
+      .replyOnce(200, [])
+      .onGet('/api/admin/UCSBSubjects/all')
+      .reply(200, loadsubjectsFixtures.threeSubjects);
+    axiosMock
+      .onPost('/api/admin/UCSBSubjects/load')
+      .reply(200, loadsubjectsFixtures.threeSubjects);
+
+    const { queryByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LoadSubjectsPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        queryByTestId(`${testId}-cell-row-0-col-id`)
+      ).not.toBeInTheDocument();
+    });
+
+    const loadButton = queryByTestId(`subjectsLoad`);
+    expect(loadButton).toBeInTheDocument();
+
+    fireEvent.click(loadButton);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LoadSubjectsPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    fireEvent.click(loadButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith('No new subjects were loaded');
+    });
+    await waitFor(() => {
+      expect(mockToast).not.toBeCalledWith('3 new subjects were loaded');
+    });
+  });
+
+  test('test that toastify reload retention notices changes', async () => {
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet('api/admin/UCSBSubjects/all')
+      .replyOnce(200, [])
+      .onGet('/api/admin/UCSBSubjects/all')
+      .replyOnce(200, loadsubjectsFixtures.threeSubjects)
+      .onGet('/api/admin/UCSBSubjects/all')
+      .reply(200, loadsubjectsFixtures.fourSubjects);
+    axiosMock
+      .onPost('/api/admin/UCSBSubjects/load')
+      .replyOnce(200, loadsubjectsFixtures.threeSubjects)
+      .onPost('/api/admin/UCSBSubjects/load')
+      .reply(200, loadsubjectsFixtures.fourSubjects);
+
+    const { queryByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LoadSubjectsPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        queryByTestId(`${testId}-cell-row-0-col-id`)
+      ).not.toBeInTheDocument();
+    });
+
+    const loadButton = queryByTestId(`subjectsLoad`);
+    expect(loadButton).toBeInTheDocument();
+
+    fireEvent.click(loadButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith('3 new subjects were loaded');
+    });
+
+    queryByTestId;
+
+    fireEvent.click(loadButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith('1 new subject was loaded');
+    });
+  });
+
+  test('test what happens when you click add a new subject to a non-empty list', async () => {
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet('/api/admin/UCSBSubjects/all')
+      .replyOnce(200, loadsubjectsFixtures.threeSubjects)
+      .onGet('/api/admin/UCSBSubjects/all')
+      .reply(200, loadsubjectsFixtures.fourSubjects);
+    axiosMock
+      .onPost('/api/admin/UCSBSubjects/load')
+      .reply(200, loadsubjectsFixtures.fourSubjects);
+
+    const { getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LoadSubjectsPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent('1');
+
+    const loadButton = getByTestId(`subjectsLoad`);
+    expect(loadButton).toBeInTheDocument();
+
+    fireEvent.click(loadButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith('1 new subject was loaded');
+    });
+
+    fireEvent.click(loadButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith('No new subjects were loaded');
+    });
+
+    mockToast.mockClear(); //clear mock history to check that toast isn't calling the same thing
+
+    fireEvent.click(loadButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith('No new subjects were loaded');
+    });
+
+    await waitFor(() => {
+      expect(mockToast).not.toBeCalledWith('1 new subject was loaded');
+    });
+  });
+
+  test('test what happens when you click add multiple new subject to a non-empty list', async () => {
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet('/api/admin/UCSBSubjects/all')
+      .replyOnce(200, loadsubjectsFixtures.threeSubjects)
+      .onGet('/api/admin/UCSBSubjects/all')
+      .reply(200, loadsubjectsFixtures.fiveSubjects);
+    axiosMock
+      .onPost('/api/admin/UCSBSubjects/load')
+      .replyOnce(200, loadsubjectsFixtures.threeSubjects)
+      .onPost('/api/admin/UCSBSubjects/load')
+      .reply(200, loadsubjectsFixtures.fiveSubjects);
+
+    const { getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LoadSubjectsPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent('1');
+
+    const loadButton = getByTestId(`subjectsLoad`);
+    expect(loadButton).toBeInTheDocument();
+
+    fireEvent.click(loadButton);
+
+    fireEvent.click(loadButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith('2 new subjects were loaded');
     });
   });
 });

--- a/frontend/src/tests/pages/LoadSubjectsPage.test.js
+++ b/frontend/src/tests/pages/LoadSubjectsPage.test.js
@@ -36,7 +36,7 @@ jest.mock('react-router-dom', () => {
 describe('LoadSubjectsPage tests', () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const testId = 'LoadSubjectsTable';
+  const testId = 'UCSBSubjectsTable';
 
   beforeEach(() => {
     axiosMock.reset();

--- a/frontend/stryker.conf.json
+++ b/frontend/stryker.conf.json
@@ -15,5 +15,6 @@
         "src/main/**/*.{js,jsx,ts,tsx}",
         "!src/main/**/*_NoStryker.{js,jsx,ts,tsx}"
     ],
-    "thresholds": { "high": 100, "low": 90, "break": 100 }
+    "thresholds": { "high": 100, "low": 90, "break": 100 },
+    "tempDirName": "stryker-tmp"
 }

--- a/frontend/stryker.conf.json
+++ b/frontend/stryker.conf.json
@@ -15,5 +15,6 @@
         "src/main/**/*.{js,jsx,ts,tsx}",
         "!src/main/**/*_NoStryker.{js,jsx,ts,tsx}"
     ],
-    "thresholds": { "high": 100, "low": 90, "break": 100 }
+    "thresholds": { "high": 100, "low": 90, "break": 100 }, 
+    "tempDirName": "stryker-tmp"
 }


### PR DESCRIPTION
# Overview

In this PR, we fix the backend bug of Load Subjects. Subjects should be loaded in properly. Toastify now remembers number of subjects loaded even when full page is reloaded. Toastify also returns the proper amount of subjects returned based on the difference between subjects on table and new subjects loaded.

# Issues Addressed

Closes #33 #36

# Details

The bug was caused by the API key not being available. It seemed to have been fixed when the branch merged to main. I modified the Load Subject Page and its tests to use UCSBSubjects instead of the placeholder LoadSubjects.