### PR TITLE
Personal Schedule Table Component

### DIFF
--- a/frontend/src/fixtures/personalSchedulesFixtures.js
+++ b/frontend/src/fixtures/personalSchedulesFixtures.js
@@ -1,0 +1,30 @@
+const personalSchedulesFixtures = {
+  oneSchedule: {
+    id: 1,
+    name: "CS156",
+    quarterYYYYQ: "20221",
+    description: "rebase all over the place!",
+  },
+  threeSchedules: [
+    {
+      id: 1,
+      name: "CS156",
+      quarterYYYYQ: "20221",
+      description: "rebase all over the place!",
+    },
+    {
+      id: 2,
+      name: "CS154",
+      quarterYYYYQ: "20221",
+      description: "Pipeline cycles wil make you smile!",
+    },
+    {
+      id: 3,
+      name: "CS130A",
+      quarterYYYYQ: "20221",
+      description: "Red-black trees will set you free!",
+    },
+  ],
+};
+
+export { personalSchedulesFixtures };

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -1,18 +1,27 @@
-import { Button, Container, Nav, Navbar, NavDropdown } from "react-bootstrap";
-import { Link } from "react-router-dom";
-import { hasRole } from "main/utils/currentUser";
-import AppNavbarLocalhost from "main/components/Nav/AppNavbarLocalhost"
+import { Button, Container, Nav, Navbar, NavDropdown } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+import { hasRole } from 'main/utils/currentUser';
+import AppNavbarLocalhost from 'main/components/Nav/AppNavbarLocalhost';
 
-export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUrl = window.location.href }) {
+export default function AppNavbar({
+  currentUser,
+  systemInfo,
+  doLogout,
+  currentUrl = window.location.href,
+}) {
   return (
     <>
-      {
-        (currentUrl.startsWith("http://localhost:3000") ||
-          currentUrl.startsWith("http://127.0.0.1:3000")) && (
-          <AppNavbarLocalhost url={currentUrl} />
-        )
-      }
-      <Navbar expand="xl" variant="dark" bg="dark" sticky="top" data-testid="AppNavbar">
+      {(currentUrl.startsWith('http://localhost:3000') ||
+        currentUrl.startsWith('http://127.0.0.1:3000')) && (
+        <AppNavbarLocalhost url={currentUrl} />
+      )}
+      <Navbar
+        expand="xl"
+        variant="dark"
+        bg="dark"
+        sticky="top"
+        data-testid="AppNavbar"
+      >
         <Container>
           <Navbar.Brand as={Link} to="/">
             Example
@@ -26,71 +35,68 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
 
           <Navbar.Collapse className="justify-content-between">
             <Nav className="me-auto">
-              {
-                systemInfo?.springH2ConsoleEnabled && (
-                  <>
-                    <Nav.Link href="/h2-console">H2Console</Nav.Link>
-                  </>
-                )
-              }
-              {
-                systemInfo?.showSwaggerUILink && (
-                  <>
-                    <Nav.Link href="/swagger-ui/index.html">Swagger</Nav.Link>
-                  </>
-                )
-              }
+              {systemInfo?.springH2ConsoleEnabled && (
+                <>
+                  <Nav.Link href="/h2-console">H2Console</Nav.Link>
+                </>
+              )}
+              {systemInfo?.showSwaggerUILink && (
+                <>
+                  <Nav.Link href="/swagger-ui/index.html">Swagger</Nav.Link>
+                </>
+              )}
             </Nav>
             <Nav className="mr-auto">
-              {
-                hasRole(currentUser, "ROLE_ADMIN") && (
-                  <NavDropdown title="Admin" id="appnavbar-admin-dropdown" data-testid="appnavbar-admin-dropdown" >
-                    <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
-                    <NavDropdown.Item href="/admin/UCSBSubjects">Load Subjects</NavDropdown.Item>
-                  </NavDropdown>
-                )
-              }
+              {hasRole(currentUser, 'ROLE_ADMIN') && (
+                <NavDropdown
+                  title="Admin"
+                  id="appnavbar-admin-dropdown"
+                  data-testid="appnavbar-admin-dropdown"
+                >
+                  <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
+                  <NavDropdown.Item href="/admin/UCSBSubjects">
+                    Load Subjects
+                  </NavDropdown.Item>
+                </NavDropdown>
+              )}
             </Nav>
-			<Nav className="mr-auto">
+            <Nav className="mr-auto">
               {hasRole(currentUser, 'ROLE_USER') && (
-                  <NavDropdown 
-				  title="PersonalSchedule" 
-				  id="appnavbar-personalSchedule-dropdown" 
-				  data-testid="appnavbar-personalSchedule-dropdown" 
-				  >
-                    <NavDropdown.Item 
-					href="/personalschedule/list"
-					data-testid="appnavbar-personalSchedule-list" 
-					>
-						List
-					</NavDropdown.Item>
-
-					{hasRole(currentUser, 'ROLE_ADMIN') && (
-						<NavDropdown.Item 
-						href="/personalschedule/create"
-						data-testid="appnavbar-personalSchedule-create" 
-						>
-							Create
-						</NavDropdown.Item>
-					)}
-                  </NavDropdown>
-                )}
-       </Nav>
+                <NavDropdown
+                  title="PersonalSchedule"
+                  id="appnavbar-personalSchedule-dropdown"
+                  data-testid="appnavbar-personalSchedule-dropdown"
+                >
+                  <NavDropdown.Item
+                    href="/personalschedule/list"
+                    data-testid="appnavbar-personalSchedule-list"
+                  >
+                    List
+                  </NavDropdown.Item>
+                  <NavDropdown.Item
+                    href="/personalschedule/create"
+                    data-testid="appnavbar-personalSchedule-create"
+                  >
+                    Create
+                  </NavDropdown.Item>
+                </NavDropdown>
+              )}
+            </Nav>
             <Nav className="ml-auto">
-              {
-                currentUser && currentUser.loggedIn ? (
-                  <>
-                    <Navbar.Text className="me-3" as={Link} to="/profile">Welcome, {currentUser.root.user.email}</Navbar.Text>
-                    <Button onClick={doLogout}>Log Out</Button>
-                  </>
-                ) : (
-                  <Button href="/oauth2/authorization/google">Log In</Button>
-                )
-              }
+              {currentUser && currentUser.loggedIn ? (
+                <>
+                  <Navbar.Text className="me-3" as={Link} to="/profile">
+                    Welcome, {currentUser.root.user.email}
+                  </Navbar.Text>
+                  <Button onClick={doLogout}>Log Out</Button>
+                </>
+              ) : (
+                <Button href="/oauth2/authorization/google">Log In</Button>
+              )}
             </Nav>
           </Navbar.Collapse>
-        </Container >
-      </Navbar >
+        </Container>
+      </Navbar>
     </>
   );
 }

--- a/frontend/src/main/components/PersonalSchedule/PersonalScheduleTable.js
+++ b/frontend/src/main/components/PersonalSchedule/PersonalScheduleTable.js
@@ -1,0 +1,82 @@
+import { hasRole } from 'main/utils/currentUser';
+import React from 'react';
+import OurTable, { ButtonColumn } from '../OurTable';
+import { useBackendMutation } from 'main/utils/useBackend';
+import {
+  cellToAxiosParamsDeleteAdmin,
+  cellToAxiosParamsDeleteUser,
+  onDeleteSuccess,
+} from 'main/utils/PersonalScheduleUtils';
+import { useNavigate } from 'react-router-dom';
+
+export default function PersonalScheduleTable({ schedules, currentUser }) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/personalschedule/edit/${cell.row.values.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    hasRole(currentUser, 'ROLE_ADMIN')
+      ? cellToAxiosParamsDeleteAdmin
+      : cellToAxiosParamsDeleteUser,
+    { onSuccess: onDeleteSuccess },
+    [
+      hasRole(currentUser, 'ROLE_ADMIN')
+        ? '/api/PersonalSchedules/admin/all'
+        : '/api/PersonalSchedules/all',
+    ]
+  );
+  // Stryker enable all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      Header: 'id',
+      accessor: 'id',
+    },
+    {
+      Header: 'Name',
+      accessor: 'name',
+    },
+    {
+      Header: 'Description',
+      accessor: 'description',
+    },
+    {
+      Header: 'Quarter (YYYYQ)',
+      accessor: 'quarterYYYYQ',
+    },
+  ];
+
+  columns.push(
+    ButtonColumn('Edit', 'primary', editCallback, 'PersonalScheduleTable')
+  );
+  columns.push(
+    ButtonColumn('Delete', 'danger', deleteCallback, 'PersonalScheduleTable')
+  );
+
+  if (hasRole(currentUser, 'ROLE_ADMIN')) {
+    columns.splice(1, 0, {
+      Header: 'User',
+      accessor: 'user.fullName',
+    });
+  }
+
+  const memoizedColumns = React.useMemo(() => columns, [columns]);
+  const memoizedSchedule = React.useMemo(() => schedules, [schedules]);
+
+  return (
+    <OurTable
+      data={memoizedSchedule}
+      columns={memoizedColumns}
+      testid={'PersonalScheduleTable'}
+    />
+  );
+}

--- a/frontend/src/main/pages/PersonalSchedule/PersonalScheduleIndexPage.js
+++ b/frontend/src/main/pages/PersonalSchedule/PersonalScheduleIndexPage.js
@@ -1,14 +1,40 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { hasRole } from "main/utils/currentUser";
+import React, { useEffect } from "react";
+import PersonalScheduleTable from "main/components/PersonalSchedule/PersonalScheduleTable";
+import { useCurrentUser } from "main/utils/currentUser";
+import { useBackend } from "main/utils/useBackend";
 
 export default function PersonalScheduleIndexPage() {
+  const currentUser = useCurrentUser();
+
+  // Stryker disable all : hard to test, the queryKey doesn't really matter
+  // but it needs to be same as the actual request
+  const {
+    data: schedule,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    [
+      hasRole(currentUser, "ROLE_ADMIN")
+        ? "/api/PersonalSchedules/admin/all"
+        : "/api/PersonalSchedules/all",
+    ],
+    {
+      method: "GET",
+      url: hasRole(currentUser, "ROLE_ADMIN")
+        ? "/api/PersonalSchedules/admin/all"
+        : "/api/PersonalSchedules/all",
+    },
+    []
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>PersonalSchedule</h1>
-        <p>
-          This is where the index page will go
-        </p>
+        <PersonalScheduleTable schedules={schedule} currentUser={currentUser} />
       </div>
     </BasicLayout>
-  )
+  );
 }

--- a/frontend/src/main/utils/PersonalScheduleUtils.js
+++ b/frontend/src/main/utils/PersonalScheduleUtils.js
@@ -1,0 +1,29 @@
+import { toast } from 'react-toastify';
+import { useNavigate } from 'react-router-dom';
+import { hasRole } from 'main/utils/currentUser';
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message.message);
+}
+
+export function cellToAxiosParamsDeleteAdmin(cell) {
+  return {
+    url: '/api/PersonalSchedules/admin',
+    method: 'DELETE',
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+}
+
+export function cellToAxiosParamsDeleteUser(cell) {
+  return {
+    url: '/api/PersonalSchedules/',
+    method: 'DELETE',
+
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/PersonalSchedule/PersonalScheduleTable.stories.js
+++ b/frontend/src/stories/components/PersonalSchedule/PersonalScheduleTable.stories.js
@@ -1,0 +1,25 @@
+import React from "react";
+
+import PersonalScheduleTable from "main/components/PersonalSchedule/PersonalScheduleTable";
+import { personalSchedulesFixtures, ucsbDatesFixtures } from "fixtures/personalSchedulesFixtures";
+
+export default {
+  title: "components/PersonalSchedule/PersonalScheduleTable",
+  component: PersonalScheduleTable,
+};
+
+const Template = (args) => {
+  return <PersonalScheduleTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  schedules: [],
+};
+
+export const ThreeSchedules = Template.bind({});
+
+ThreeSchedules.args = {
+  schedules: personalSchedulesFixtures.threeSchedules,
+};

--- a/frontend/src/tests/components/PersonalSchedule/PersonalScheduleTable.test.js
+++ b/frontend/src/tests/components/PersonalSchedule/PersonalScheduleTable.test.js
@@ -1,0 +1,151 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { personalSchedulesFixtures } from "fixtures/personalSchedulesFixtures";
+import PersonalScheduleTable from "main/components/PersonalSchedule/PersonalScheduleTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+const mockedNavigate = jest.fn();
+
+const mockedMutate = jest.fn();
+
+jest.mock("main/utils/useBackend", () => ({
+  ...jest.requireActual("main/utils/useBackend"),
+  useBackendMutation: () => ({ mutate: mockedMutate }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("UserTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalScheduleTable schedules={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalScheduleTable schedules={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalScheduleTable schedules={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  });
+
+  test("Has the expected colum headers and content for adminUser", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalScheduleTable
+            schedules={personalSchedulesFixtures.threeSchedules}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const expectedHeaders = ["id", "User", "Name", "Description", "Quarter (YYYYQ)"];
+    const expectedFields = ["id", "user.fullName", "name", "description", "quarterYYYYQ"];
+    const testId = "PersonalScheduleTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Edit button navigates to the edit page for admin user", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalScheduleTable
+            schedules={personalSchedulesFixtures.threeSchedules}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId(`PersonalScheduleTable-cell-row-0-col-id`)).toHaveTextContent("1");
+    });
+
+    const editButton = getByTestId(`PersonalScheduleTable-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+
+    fireEvent.click(editButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith("/personalschedule/edit/1"));
+  });
+
+  test("Delete button calls the delete call back", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalScheduleTable
+            schedules={personalSchedulesFixtures.threeSchedules}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId(`PersonalScheduleTable-cell-row-0-col-id`)).toHaveTextContent("1");
+    });
+
+    const deleteButton = getByTestId(`PersonalScheduleTable-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(mockedMutate).toHaveBeenCalledTimes(1));
+  });
+});

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalScheduleIndexPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalScheduleIndexPage.test.js
@@ -1,24 +1,39 @@
-import { render } from "@testing-library/react";
-import PersonalScheduleIndexPage from "main/pages/PersonalSchedule/PersonalScheduleIndexPage";
+import { render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import PersonalScheduleIndexPage from "main/pages/PersonalSchedule/PersonalScheduleIndexPage";
+import { personalSchedulesFixtures } from "fixtures/personalSchedulesFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
 
 describe("PersonalScheduleIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
-  axiosMock
-    .onGet("/api/currentUser")
-    .reply(200, apiCurrentUserFixtures.userOnly);
-  axiosMock
-    .onGet("/api/systemInfo")
-    .reply(200, systemInfoFixtures.showingNeither);
+  const testId = "PersonalScheduleTable";
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+  };
 
-  const queryClient = new QueryClient();
-  test("renders without crashing", () => {
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  test("renders without crashing for regular user", () => {
+    setupUserOnly();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/PersonalSchedules/all").reply(200, []);
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -26,5 +41,92 @@ describe("PersonalScheduleIndexPage tests", () => {
         </MemoryRouter>
       </QueryClientProvider>
     );
+  });
+
+  test("renders without crashing for admin user", () => {
+    setupAdminUser();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/PersonalSchedules/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalScheduleIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  });
+
+  test("renders three PersonalSchedule without crashing for regular user", async () => {
+    setupUserOnly();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/PersonalSchedules/all")
+      .reply(200, personalSchedulesFixtures.threeSchedules);
+
+    const { getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalScheduleIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("CS156");
+    });
+    expect(getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("CS154");
+    expect(getByTestId(`${testId}-cell-row-2-col-name`)).toHaveTextContent("CS130A");
+  });
+
+  test("renders three schedules without crashing for admin user", async () => {
+    setupAdminUser();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/PersonalSchedules/admin/all")
+      .reply(200, personalSchedulesFixtures.threeSchedules);
+
+    const { getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalScheduleIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("CS156");
+    });
+    expect(getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("CS154");
+    expect(getByTestId(`${testId}-cell-row-2-col-name`)).toHaveTextContent("CS130A");
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/PersonalSchedules/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    const { queryByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalScheduleIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/PersonalSchedules/"
+    );
+    restoreConsole();
+
+    expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/utils/PersonalScheduleUtils.test.js
+++ b/frontend/src/tests/utils/PersonalScheduleUtils.test.js
@@ -1,0 +1,71 @@
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDeleteUser,
+  cellToAxiosParamsDeleteAdmin,
+  editCallback,
+} from 'main/utils/PersonalScheduleUtils';
+import mockConsole from 'jest-mock-console';
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+  const originalModule = jest.requireActual('react-toastify');
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe('PersonalScheduleUtils', () => {
+  describe('onDeleteSuccess', () => {
+    test('It puts the message on console.log and in a toast', () => {
+      // arrange
+      const restoreConsole = mockConsole();
+      // act
+      const success = {
+        message: 'abc',
+      };
+      onDeleteSuccess(success);
+      // assert
+      expect(mockToast).toHaveBeenCalledWith('abc');
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toEqual({ message: 'abc' });
+
+      restoreConsole();
+    });
+  });
+  describe('cellToAxiosParamsDeleteUser', () => {
+    test('It returns the correct params', () => {
+      // arrange
+      const cell = { row: { values: { id: 99 } } };
+
+      // act
+      const result = cellToAxiosParamsDeleteUser(cell);
+
+      // assert
+      expect(result).toEqual({
+        url: '/api/PersonalSchedules/',
+        method: 'DELETE',
+        params: { id: 99 },
+      });
+    });
+  });
+
+  describe('cellToAxiosParamsDeleteAdmin', () => {
+    test('It returns the correct params', () => {
+      // arrange
+      const cell = { row: { values: { id: 99 } } };
+
+      // act
+      const result = cellToAxiosParamsDeleteAdmin(cell);
+
+      // assert
+      expect(result).toEqual({
+        url: '/api/PersonalSchedules/admin',
+        method: 'DELETE',
+        params: { id: 99 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Overview

In this PR, we added a schedule table component that will display schedules loaded in from the backend and created by the user. The table component is displayed on the Personal Schedule Index page, which is accessible by the Navbar. The edit button does not work yet.

# Issues Addressed

Closes #25 

# Details

- There a table component viewable on storybook
- Table will display a list of schedules with an edit and delete button 
- Utils were created to handle delete requests. A toast should appear as well
- Fixtures were added for testing
- NavBar was updated to properly display pages to users and admins
- IndexPage is added to host the table, with conditional statements based on user or admin to GET the proper schedules for table to display
