### PR TITLE
Changing timeout-minutes to 40 from 10

### DIFF
--- a/.github/workflows/02-frontend-01-tests.yml
+++ b/.github/workflows/02-frontend-01-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 40
 
     strategy:
       matrix:


### PR DESCRIPTION
Required because npx stryker run timesout in this PR 
https://github.com/ucsb-cs156-w22/team04-w22-7pm-courses/runs/5526962736?check_suite_focus=true
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/72826259/158057183-f8b5212a-f5fc-4c17-9cae-e470ba808a50.png">
